### PR TITLE
Made plugin use the DokuWiki proxy settings

### DIFF
--- a/action.php
+++ b/action.php
@@ -29,9 +29,9 @@ class action_plugin_slackhq extends DokuWiki_Action_Plugin {
     function handle_action_act_preprocess(&$event, $param) {
         global $lang;
         if (isset($event->data['save'])) {
-            if ($event->data['save'] == $lang['btn_save']) {
+            //if ($event->data['save'] == $lang['btn_save']) {
                 $this->handle();
-            }
+            //}
         }
         return;
     }


### PR DESCRIPTION
Hi

I've made the plugin use the DokuWiki proxy settings when making its cURL call.

I haven't really used DokuWiki much and have only tested this to ensure it works with the proxy settings for my setup, i.e. I hope I haven't broken posting when proxy settings are not set.

Let me know if you want any other changes before you merge it.

Thanks
Dean
